### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: alpine
           build-args: |

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -138,7 +138,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: debian
           build-args: |

--- a/.github/workflows/rocky.yml
+++ b/.github/workflows/rocky.yml
@@ -138,7 +138,7 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
       - name: Build and push
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v6.19.2
         with:
           context: rocky
           build-args: |


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2)** on 2026-02-12T08:51:07Z
